### PR TITLE
Fix hide from sitemap SEO documentation link

### DIFF
--- a/shopifyFD.js
+++ b/shopifyFD.js
@@ -2761,7 +2761,7 @@
 
           });
 
-          sectionVisibility.append('<p style="margin:1em 0">Add metafield to remove this product from the sitemap. It is <b>very</b> important that you <a href="http://docs.shopify.com/api/unlinked/hide-from-search-engines-and-sitemaps" target="_blank">understand</a> what doing this means. If you don\'t, leave it alone.</p>',seohideBtn);
+          sectionVisibility.append('<p style="margin:1em 0">Add metafield to remove this product from the sitemap. It is <b>very</b> important that you <a href="https://help.shopify.com/api/tutorials/updating-seo-data#hide-an-object-from-search-engines-and-sitemaps" target="_blank">understand</a> what doing this means. If you don\'t, leave it alone.</p>',seohideBtn);
 
         }
       }


### PR DESCRIPTION
The SEO documentation link currently present in Shopify FD is broken – I think they may have changed up the URL structure at some point. This is just a simple fix to address that.